### PR TITLE
Fix example in GCop129

### DIFF
--- a/Rules/GCop129.md
+++ b/Rules/GCop129.md
@@ -27,7 +27,7 @@ public class MyClass
 ```csharp
 public class MyClass
 {
-    public static bool Add()
+    public bool Add()
     {
         DbContext.EntityName.Add(this);
         ...


### PR DESCRIPTION
The "this" reference can't be used in a static method